### PR TITLE
feat: Complete Phase 1 dependency upgrades (Next.js, React, MDX)

### DIFF
--- a/data/publications.json
+++ b/data/publications.json
@@ -1,6 +1,6 @@
 [
   {
-    "title": "Papercuts: The little fixes that made a big difference at GitHub"
+    "title": "Papercuts: The little fixes that made a big difference at GitHub",
     "url": "https://kathykorevec.substack.com/p/papercuts-the-little-fixes-that-made" 
   },
   {

--- a/next.config.js
+++ b/next.config.js
@@ -1,15 +1,35 @@
 const fs = require('fs');
-const withMDX = require('@next/mdx')({
-  extension: /\.mdx?$/,
-});
+const createMDX = require('@next/mdx')
 
-module.exports = withMDX({
+// New MDX setup for Next.js 14+
+const withMDX = createMDX({
+  // Add experimental support for MDX-RS
+  experimental: {
+    mdxRs: true,
+  },
+  // Keep original extension handling
+  extension: /\.mdx?$/,
+  options: {
+    remarkPlugins: [], // Add any remark plugins here
+    rehypePlugins: [], // Add any rehype plugins here
+  },
+})
+
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  // Preserve existing env configuration
   env: {
    noflash: fs.readFileSync('./public/scripts/noflash.js').toString()
  },
+ // Preserve existing i18n configuration
   i18n: {
     locales: ['en-US'],
     defaultLocale: 'en-US',
   },
-  pageExtensions: ['js', 'jsx', 'mdx'],
-});
+  // Ensure 'md' and 'mdx' are included
+  pageExtensions: ['js', 'jsx', 'ts', 'tsx', 'md', 'mdx'],
+  // Add other Next.js config options here if needed
+};
+
+// Apply the MDX configuration to the Next.js config
+module.exports = withMDX(nextConfig);

--- a/package.json
+++ b/package.json
@@ -8,10 +8,13 @@
     "start": "next start"
   },
   "dependencies": {
+    "@mdx-js/loader": "^1.6.22",
+    "@mdx-js/react": "^1.6.22",
+    "@next/mdx": "^14.2.3",
     "@tailwindcss/typography": "^0.4.1",
-    "next": "^14.2.3",
-    "react": "^18.2.0",
-    "react-dom": "^18.2.0"
+    "next": "latest",
+    "react": "^17.0.2",
+    "react-dom": "^17.0.2"
   },
   "devDependencies": {
     "autoprefixer": "^10.2.6",
@@ -19,6 +22,6 @@
     "tailwindcss": "^2.2.4"
   },
   "engines": {
-    "node": "18.x"
+    "node": "16.20.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -22,6 +22,6 @@
     "tailwindcss": "^2.2.4"
   },
   "engines": {
-    "node": "16.20.2"
+    "node": "18.x"
   }
 }

--- a/package.json
+++ b/package.json
@@ -8,13 +8,10 @@
     "start": "next start"
   },
   "dependencies": {
-    "@mdx-js/loader": "^1.6.22",
-    "@mdx-js/react": "^1.6.22",
-    "@next/mdx": "^11.0.1",
     "@tailwindcss/typography": "^0.4.1",
-    "next": "latest",
-    "react": "^17.0.2",
-    "react-dom": "^17.0.2"
+    "next": "^14.2.3",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
   },
   "devDependencies": {
     "autoprefixer": "^10.2.6",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,6 @@
     "tailwindcss": "^2.2.4"
   },
   "engines": {
-    "node": "16.20.2"
+    "node": "18.x"
   }
 }


### PR DESCRIPTION
This commit completes the first phase of the dependency upgrade plan:

- Updated Node.js environment to v18.19.0 temporarily using nvm for compatibility during upgrades.
- Updated Next.js to ^14.2.3 in package.json.
- Updated React and React-DOM to ^18.2.0 in package.json.
- Removed deprecated MDX v1 dependencies (@mdx-js/loader, @mdx-js/react, @next/mdx@^11).
- Deleted node_modules and yarn.lock and reinstalled dependencies using yarn install.
- Installed new @next/mdx@^14.2.3 dependency.
- Updated next.config.js to use the new Next.js 14 MDX configuration (@next/mdx plugin, mdxRs enabled), preserving existing env and i18n settings.

Verification Blocked:
I attempted to verify the build (`yarn build`, `npx next build`) and development server (`yarn dev`), but encountered persistent errors ("Command 'build' not found", "Couldn't find any `pages` or `app` directory"). These errors occurred despite the presence of the build script in package.json and the pages directory. This suggests an issue preventing Next.js from correctly identifying the project structure or running scripts.

Therefore, I couldn't confirm the stability of the application after these Phase 1 changes. Further investigation or running in a different environment is needed to proceed with verification and the subsequent upgrade phases (Node.js upgrade, Tailwind upgrade).