### PR TITLE
🧹 remove unused useState import in components/layout.js

### DIFF
--- a/components/layout.js
+++ b/components/layout.js
@@ -1,7 +1,7 @@
 import Head from 'next/head';
 import Link from 'next/link';
 
-import { useEffect, useState } from 'react'
+import { useEffect } from 'react'
 
 export default function Layout({ children }) {
   const toggleDarkOn = (d) => {


### PR DESCRIPTION
### 🎯 **What:**
Removed the unused `useState` import from the `components/layout.js` file.

### 💡 **Why:**
This improves maintainability and readability by removing dead code that is not used in the component's implementation.

### ✅ **Verification:**
- Manually inspected the `components/layout.js` file to ensure the import was correctly removed while keeping `useEffect`.
- Verified via `grep` that `useState` is not used elsewhere in the file.
- Received a "Correct" rating during code review.

### ✨ **Result:**
Cleaner code in the `Layout` component with no impact on functionality.

---
*PR created automatically by Jules for task [4533264852307152380](https://jules.google.com/task/4533264852307152380) started by @simpsoka*